### PR TITLE
update to api provided by Suave 1.1.0

### DIFF
--- a/site/webserver.fsx
+++ b/site/webserver.fsx
@@ -7,18 +7,17 @@
 
 open Fake
 open Suave
-open Suave.Http.Successful
+open Suave.Successful
 open Suave.Web
-open Suave.Types
 open System.Net
 
-let serverConfig = 
+let serverConfig =
     let port = getBuildParamOrDefault "port" "8083" |> Sockets.Port.Parse
     { defaultConfig with bindings = [ HttpBinding.mk HTTP IPAddress.Loopback port ] }
 
-startWebServer serverConfig 
-    (OK  
-        ("Hello World! It's Suave.io on Azure Websites.<br /><ul>" + 
-          "<li>Sample git Repo: <a href='https://github.com/shanselman/suavebootstrapper'>https://github.com/shanselman/suavebootstrapper</a></li>" +
-          "<li>Intro blog post: <a href='http://www.hanselman.com/blog/RunningSuaveioAndFWithFAKEInAzureWebAppsWithGitAndTheDeployButton.aspx'>http://www.hanselman.com/blog/RunningSuaveioAndFWithFAKEInAzureWebAppsWithGitAndTheDeployButton.aspx</a></li>" +
-          "</ul>"))
+startWebServer serverConfig
+    (OK
+        ("Hello World! It's Suave.io on Azure Websites.<br /><ul>" +
+         "<li>Sample git Repo: <a href='https://github.com/shanselman/suavebootstrapper'>https://github.com/shanselman/suavebootstrapper</a></li>" +
+         "<li>Intro blog post: <a href='http://www.hanselman.com/blog/RunningSuaveioAndFWithFAKEInAzureWebAppsWithGitAndTheDeployButton.aspx'>http://www.hanselman.com/blog/RunningSuaveioAndFWithFAKEInAzureWebAppsWithGitAndTheDeployButton.aspx</a></li>" +
+         "</ul>"))


### PR DESCRIPTION
The current version of Suave is 1.1.0 and the `Successful` module is now under `Suave` rather than `Suave.Http`
